### PR TITLE
Fix 422 unknown API error on empty voice settings array

### DIFF
--- a/src/Traits/TextToSpeechTrait.php
+++ b/src/Traits/TextToSpeechTrait.php
@@ -16,7 +16,7 @@ trait TextToSpeechTrait
             'json' => [
                 'text' => $text,
                 'model_id' => $modelId,
-                'voice_settings' => $voiceSettings,
+                ...($voiceSettings) ? ['voice_settings' => $voiceSettings] : [],
             ],
             'headers' => [
                 'Accept' => 'audio/mpeg',


### PR DESCRIPTION
The ElevenLabs Text-to-Speech API returns a 422 unknown error when the request includes an empty voice_settings array ([]). Even though the field is optional, sending it as an empty array makes the payload invalid.